### PR TITLE
allow overriding cgroup.conf template and fix destination

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ roles:
   - src: stackhpc.nfs
     version: v23.12.1 # Tolerate state nfs file handles
   - src: https://github.com/stackhpc/ansible-role-openhpc.git
-    version: a34dace # https://github.com/stackhpc/ansible-role-openhpc/pull/163 # TODO: bump on release
+    version: 51b5031 # https://github.com/stackhpc/ansible-role-openhpc/pull/163 # TODO: bump on release
     name: stackhpc.openhpc
   - src: https://github.com/stackhpc/ansible-node-exporter.git
     version: stackhpc


### PR DESCRIPTION
Bumps the stackhpc.openhpc role to:
1. Ensure cgroup.conf is written next to slurm.conf
2. Enable customisting it, e.g. using:


```yaml
#environments/$ENV/inventory/group_vars/all/openhpc.yml:
openhpc_cgroup_template:  "{{ appliances_environment_root }}/cgroup.conf.j2"
```

And creating that file in the current environment.

**NB**: because this PR changes galaxy requirements, after pulling this branch run:

```
dev/setup-env.sh
```

to update installed collections/roles